### PR TITLE
touchpanel gestures

### DIFF
--- a/drivers/input/touchscreen/synaptics_dsx_i2c.c
+++ b/drivers/input/touchscreen/synaptics_dsx_i2c.c
@@ -956,7 +956,7 @@ error_set_vtg_vcc_ana:
 }
 
 static int synaptics_rmi4_update_gesture2(unsigned char *gesture,
-				      	unsigned char *gestureext)
+		unsigned char *gestureext)
 {
 	int i;
 	int keyvalue = 0;

--- a/drivers/input/touchscreen/synaptics_dsx_i2c.c
+++ b/drivers/input/touchscreen/synaptics_dsx_i2c.c
@@ -955,11 +955,11 @@ error_set_vtg_vcc_ana:
 	return rc;
 }
 
-static unsigned char synaptics_rmi4_update_gesture2(unsigned char *gesture,
-		unsigned char *gestureext)
+static int synaptics_rmi4_update_gesture2(unsigned char *gesture,
+				      	unsigned char *gestureext)
 {
 	int i;
-	unsigned char keyvalue = 0;
+	int keyvalue = 0;
 	unsigned char gesturemode;
 	unsigned short points[16];
 
@@ -1073,7 +1073,7 @@ static int synaptics_rmi4_f12_abs_report(struct synaptics_rmi4_data *rmi4_data,
 	struct synaptics_rmi4_f12_finger_data *finger_data;
 	unsigned char gesture[5];
 	unsigned char gestureext[25];
-	unsigned char keyvalue;
+	int keyvalue;
 	unsigned int  finger_info = 0;
 	u64 now = ktime_to_ms(ktime_get());
 

--- a/drivers/input/touchscreen/synaptics_dsx_i2c.c
+++ b/drivers/input/touchscreen/synaptics_dsx_i2c.c
@@ -1967,7 +1967,7 @@ static int synaptics_rmi4_set_input_dev(struct synaptics_rmi4_data *rmi4_data)
 
 	atomic_set(&rmi4_data->keypad_enable, 1);
 	atomic_set(&rmi4_data->syna_use_gesture, 1);
-	atomic_set(&rmi4_data->double_tap_enable, 1);
+	atomic_set(&rmi4_data->double_tap_enable, 0);
 	atomic_set(&rmi4_data->camera_enable, 0);
 	atomic_set(&rmi4_data->music_enable, 0);
 	atomic_set(&rmi4_data->flashlight_enable, 0);

--- a/include/linux/input.h
+++ b/include/linux/input.h
@@ -473,15 +473,6 @@ struct input_keymap_entry {
 
 #define KEY_MICMUTE		248	/* Mute / unmute the microphone */
 
-#ifdef CONFIG_MACH_OPPO
-#define KEY_GESTURE_CIRCLE	250
-#define KEY_GESTURE_SWIPE_DOWN	251
-#define KEY_GESTURE_V		252
-#define KEY_GESTURE_LTR		253
-#define KEY_GESTURE_GTR		254
-#define KEY_DOUBLE_TAP		255
-#endif
-
 /* Code 255 is reserved for special needs of AT keyboard driver */
 
 #define BTN_MISC		0x100
@@ -717,6 +708,23 @@ struct input_keymap_entry {
 #define KEY_CAMERA_DOWN		0x218
 #define KEY_CAMERA_LEFT		0x219
 #define KEY_CAMERA_RIGHT	0x21a
+
+// from newer kernel
+#define KEY_ATTENDANT_ON	0x21b
+#define KEY_ATTENDANT_OFF	0x21c
+#define KEY_ATTENDANT_TOGGLE	0x21d	/* Attendant call on or off */
+#define KEY_LIGHTS_TOGGLE	0x21e	/* Reading light on or off */
+
+// map gesture key codes to codes that will be passed on by libinput
+// and might be handled by Mir as media keys (as in not changing the power state)
+#ifdef CONFIG_MACH_OPPO
+#define KEY_GESTURE_CIRCLE	KEY_CAMERA            // was 250
+#define KEY_GESTURE_SWIPE_DOWN	KEY_PLAYPAUSE         // was 251
+#define KEY_GESTURE_V		KEY_ATTENDANT_TOGGLE  // was 252
+#define KEY_GESTURE_LTR		KEY_PREVIOUSSONG      // was 253
+#define KEY_GESTURE_GTR		KEY_NEXTSONG          // was 254
+#define KEY_DOUBLE_TAP		KEY_POWER             // was 255
+#endif
 
 #define BTN_TRIGGER_HAPPY		0x2c0
 #define BTN_TRIGGER_HAPPY1		0x2c0


### PR DESCRIPTION
The synaptics touchpanel driver notifies some gestures as key events. libinput however does not recognize these keys and filters them out so they will not arrive at mir. 

This pr maps the gesture events to some not filtered out media keys and the double tap to the power key.

Since the double tap gesture was enabled by default but not handled I disabled it now by default as to not have unwanted functionality.